### PR TITLE
Fix broken HNN logo

### DIFF
--- a/templates/topbar.html
+++ b/templates/topbar.html
@@ -63,7 +63,7 @@
         <div class="topbar-logo-container">
             <img 
                 id="topbar-logo"
-                src="https://hnn.brown.edu/wp-content/uploads/hnn-medium.png"
+                src="https://raw.githubusercontent.com/jonescompneurolab/jones-website/master/images/frontpage/logos/logo-hnn-medium.png"
             />
         </div>
 


### PR DESCRIPTION
Topbar was dependent on the
old wordpress image storage,
this fixes it