### PR TITLE
[MRG] Update environment for hnn-core v0.4.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Test MPI
         run: |
-          conda run -n website-redesign-mpi \
+          conda run -n textbook-env-mpi \
           mpiexec -np 2 nrniv -mpi -python -c '
           from neuron import h;
           from mpi4py import MPI;
@@ -38,7 +38,7 @@ jobs:
           cat .gitignore
 
       - name: Build Website
-        run: conda run -n website-redesign-mpi env PYTHONUNBUFFERED=1 python build.py --execute-notebooks
+        run: conda run -n textbook-env-mpi env PYTHONUNBUFFERED=1 python build.py --execute-notebooks
 
       - name: Deploy to GitHub Pages
         if: github.repository == 'jonescompneurolab/textbook' && github.ref == 'refs/heads/main'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 .PHONY: all build clean create-conda-env create-conda-env-mpi
 
+HNN_VERSION := 0.4.2
 OS := $(shell uname -s)
 
 all: build
@@ -15,14 +16,10 @@ clean:
 	rm -rf content/*.html
 	rm -rf content/*/*.html
 
-create-conda-env:
-	conda env create --yes --file environment.yml
-	conda run -n website-redesign pip install 'hnn_core[dev]==0.4.1'
-
 create-conda-env-mpi:
-	conda env create --yes --file environment.yml --name website-redesign-mpi
-	conda install -y -n website-redesign-mpi conda-forge::openmpi conda-forge::mpi4py
-	@CONDA_ENV_PATH=$$(conda run -n website-redesign-mpi python -c "import os; print(os.environ['CONDA_PREFIX'])"); \
+	conda env create --yes --file environment.yml --name textbook-env-mpi
+	conda install -y -n textbook-env-mpi conda-forge::openmpi conda-forge::mpi4py
+	@CONDA_ENV_PATH=$$(conda run -n textbook-env-mpi python -c "import os; print(os.environ['CONDA_PREFIX'])"); \
 	mkdir -p $$CONDA_ENV_PATH/etc/conda/activate.d ; \
 	mkdir -p $$CONDA_ENV_PATH/etc/conda/deactivate.d ; \
 	if [ "$(OS)" = "Darwin" ]; then \
@@ -36,5 +33,5 @@ create-conda-env-mpi:
 		echo "export LD_LIBRARY_PATH=\$$OLD_LD_LIBRARY_PATH" >> "$$CONDA_ENV_PATH/etc/conda/deactivate.d/env_vars.sh"; \
 		echo "unset OLD_LD_LIBRARY_PATH" >> "$$CONDA_ENV_PATH/etc/conda/deactivate.d/env_vars.sh"; \
 	fi; \
-	conda run -n website-redesign-mpi pip install 'hnn_core[dev]==0.4.1'; \
-	echo "Conda environment 'website-redesign-mpi' successfully created."
+	conda run -n textbook-env-mpi pip install 'hnn_core[dev]==$(HNN_VERSION)'; \
+	echo "Conda environment 'textbook-env-mpi' successfully created."

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Website Redesign
+# HNN Textbook Source Code
 
 ## Where to access the deployed verison of this website?
 
@@ -25,4 +25,4 @@ Click here: <https://jonescompneurolab.github.io/textbook/content/preface.html>
 make create-conda-env-mpi
 ```
 
-The above will create a new Conda environment named `website-redesign-mpi` which you should use for building the HTML output in this repo.
+The above will create a new Conda environment named `textbook-env-mpi` which you should use for building the HTML output in this repo.

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: website-redesign
+name: textbook-env
 channels:
   - conda-forge
 dependencies:


### PR DESCRIPTION
This does a few things:

1. Upgrades the version of `hnn-core` installed to v0.4.2 in the main environment created by the Makefile recipe `create-conda-env-mpi`.
2. Removes the non-MPI `create-conda-env`, since ideally, anyone actually executing notebooks and then pushing content updates should be using a version of HNN-Core that has ALL development packages and features enabled.
3. Renames all uses of "Website Redesign" to "Textbook" or similar. For example, the aforementioned conda environment is renamed from `website-redesign-mpi` to `textbook-env-mpi`. The README repository title has also been updated for this, since this is now the official, current Textbook website repo, instead of just being a planned redesign.

What this does *not* do is actually re-run all the notebooks using HNN-Core v0.4.2. That will be done in a later PR.