### PR TITLE
[WIP]: Bug: Fix Markdown changes not being applied

### DIFF
--- a/content/05_erps/plot_simulate_evoked.ipynb
+++ b/content/05_erps/plot_simulate_evoked.ipynb
@@ -11,7 +11,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "This example demonstrates how to simulate a threshold level tactile\n",
+        "This example DEBUG TEST demonstrates how to simulate a threshold level tactile\n",
         "evoked response, as detailed in the [HNN GUI ERP tutorial](),\n",
         "using HNN-core. We recommend you first review the GUI tutorial.\n",
         "\n",


### PR DESCRIPTION
Currently, it seems that text-only (i.e. no code) changes to Markdown cells in notebook files are not being propagated to the resulting web pages being built.

As an example, the first commit on this branch/PR d6d132d contains only a single tiny change to the first Markdown cell of the ERP API tutorial notebook. If you build this locally, this text change does *not* show up on the resulting webpages for most build methods:

1. Running top-level `make`: Does not update the page correctly.
2. Running top-level `make execute-notebooks`: Does not update the page correctly.
3. Running top-level `make force-execute-all-notebooks`: Works, and does update the page correctly.